### PR TITLE
feat(frontend): add client registration and dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-chartjs-2": "^5.3.0",
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.1"
       },
       "devDependencies": {
         "@types/react": "^19.1.10",
@@ -822,6 +825,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.30",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz",
@@ -1328,12 +1337,33 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1620,6 +1650,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -1640,6 +1680,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
+      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
+      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/rollup": {
@@ -1697,6 +1775,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "chart.js": "^4.5.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-chartjs-2": "^5.3.0",
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.1"
   },
   "devDependencies": {
     "@types/react": "^19.1.10",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,81 +1,26 @@
 import React from 'react';
-
-type Cliente = {
-  id: number;
-  nome: string;
-  previsoes: Previsao[];
-};
-
-type Previsao = {
-  id: number;
-  data_pesagem: string;
-  peso_atual: number;
-  peso_previsto: number;
-};
+import { Routes, Route, Link } from 'react-router-dom';
+import Home from './Home';
+import CadastroCliente from './CadastroCliente';
+import Dashboard from './Dashboard';
 
 const App: React.FC = () => {
-  const [clientes, setClientes] = React.useState<Cliente[]>([]);
-  const [form, setForm] = React.useState({
-    id_cliente: '',
-    data_pesagem: '',
-    peso_atual: '',
-    peso_previsto: ''
-  });
-
-  React.useEffect(() => {
-    fetch('http://localhost:3001/clientes')
-      .then(r => r.json())
-      .then(setClientes);
-  }, []);
-
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await fetch('http://localhost:3001/previsoes', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        id_cliente: Number(form.id_cliente),
-        data_pesagem: form.data_pesagem,
-        peso_atual: Number(form.peso_atual),
-        peso_previsto: Number(form.peso_previsto)
-      })
-    });
-    setForm({ id_cliente: '', data_pesagem: '', peso_atual: '', peso_previsto: '' });
-    const clientes = await fetch('http://localhost:3001/clientes').then(r => r.json());
-    setClientes(clientes);
-  };
-
   return (
     <div className="container">
       <h1>Gestão de Peso</h1>
-      <form className="card" onSubmit={submit}>
-        <h2>Adicionar Previsão</h2>
-        <select value={form.id_cliente} onChange={e => setForm({ ...form, id_cliente: e.target.value })} required>
-          <option value="">Selecione o cliente</option>
-          {clientes.map(c => (
-            <option key={c.id} value={c.id}>{c.nome}</option>
-          ))}
-        </select>
-        <input type="date" value={form.data_pesagem} onChange={e => setForm({ ...form, data_pesagem: e.target.value })} required />
-        <input type="number" step="0.1" placeholder="Peso atual" value={form.peso_atual} onChange={e => setForm({ ...form, peso_atual: e.target.value })} required />
-        <input type="number" step="0.1" placeholder="Peso previsto" value={form.peso_previsto} onChange={e => setForm({ ...form, peso_previsto: e.target.value })} required />
-        <button type="submit">Salvar</button>
-      </form>
-      <div className="card">
-        <h2>Clientes</h2>
-        {clientes.map(c => (
-          <div key={c.id} className="cliente">
-            <strong>{c.nome}</strong>
-            <ul>
-              {c.previsoes.map(p => (
-                <li key={p.id}>{new Date(p.data_pesagem).toLocaleDateString()} - {p.peso_atual}kg / {p.peso_previsto}kg</li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
+      <nav>
+        <Link to="/">Previsões</Link>
+        <Link to="/cadastro">Cadastrar Cliente</Link>
+        <Link to="/dashboard">Dashboard</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/cadastro" element={<CadastroCliente />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
     </div>
   );
 };
 
 export default App;
+

--- a/frontend/src/CadastroCliente.tsx
+++ b/frontend/src/CadastroCliente.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const CadastroCliente: React.FC = () => {
+  const [nome, setNome] = React.useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('http://localhost:3001/clientes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nome }),
+    });
+    setNome('');
+  };
+
+  return (
+    <div className="card">
+      <h2>Cadastrar Cliente</h2>
+      <form onSubmit={submit}>
+        <input
+          type="text"
+          placeholder="Nome do cliente"
+          value={nome}
+          onChange={e => setNome(e.target.value)}
+          required
+        />
+        <button type="submit">Salvar</button>
+      </form>
+    </div>
+  );
+};
+
+export default CadastroCliente;
+

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+  Chart,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import { Cliente } from './types';
+
+Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Legend);
+
+const Dashboard: React.FC = () => {
+  const [clientes, setClientes] = React.useState<Cliente[]>([]);
+  const [idCliente, setIdCliente] = React.useState('');
+
+  React.useEffect(() => {
+    fetch('http://localhost:3001/clientes')
+      .then(r => r.json())
+      .then(setClientes);
+  }, []);
+
+  const cliente = clientes.find(c => c.id === Number(idCliente));
+  const previsoes = cliente ? [...cliente.previsoes].sort((a, b) =>
+    new Date(a.data_pesagem).getTime() - new Date(b.data_pesagem).getTime()
+  ) : [];
+
+  const data = {
+    labels: previsoes.map(p => new Date(p.data_pesagem).toLocaleDateString()),
+    datasets: [
+      {
+        label: 'Peso',
+        data: previsoes.map(p => p.peso_atual),
+        borderColor: '#0d6efd',
+        fill: false,
+      },
+      {
+        label: 'Previsto',
+        data: previsoes.map(p => p.peso_previsto),
+        borderColor: '#fd7e14',
+        fill: false,
+      },
+    ],
+  };
+
+  return (
+    <div className="card">
+      <h2>Dashboard</h2>
+      <select value={idCliente} onChange={e => setIdCliente(e.target.value)}>
+        <option value="">Selecione o cliente</option>
+        {clientes.map(c => (
+          <option key={c.id} value={c.id}>
+            {c.nome}
+          </option>
+        ))}
+      </select>
+      {cliente && <Line data={data} />}
+    </div>
+  );
+};
+
+export default Dashboard;
+

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { Cliente } from './types';
+
+type FormState = {
+  id_cliente: string;
+  data_pesagem: string;
+  peso_atual: string;
+  peso_previsto: string;
+};
+
+const Home: React.FC = () => {
+  const [clientes, setClientes] = React.useState<Cliente[]>([]);
+  const [form, setForm] = React.useState<FormState>({
+    id_cliente: '',
+    data_pesagem: '',
+    peso_atual: '',
+    peso_previsto: '',
+  });
+
+  const loadClientes = async () => {
+    const data = await fetch('http://localhost:3001/clientes').then(r => r.json());
+    setClientes(data);
+  };
+
+  React.useEffect(() => {
+    loadClientes();
+  }, []);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('http://localhost:3001/previsoes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id_cliente: Number(form.id_cliente),
+        data_pesagem: form.data_pesagem,
+        peso_atual: Number(form.peso_atual),
+        peso_previsto: Number(form.peso_previsto),
+      }),
+    });
+    setForm({ id_cliente: '', data_pesagem: '', peso_atual: '', peso_previsto: '' });
+    await loadClientes();
+  };
+
+  return (
+    <>
+      <div className="card">
+        <h2>Adicionar Previsão</h2>
+        <form onSubmit={submit}>
+          <select
+            value={form.id_cliente}
+            onChange={e => setForm({ ...form, id_cliente: e.target.value })}
+            required
+          >
+            <option value="">Selecione o cliente</option>
+            {clientes.map(c => (
+              <option key={c.id} value={c.id}>
+                {c.nome}
+              </option>
+            ))}
+          </select>
+          <input
+            type="date"
+            value={form.data_pesagem}
+            onChange={e => setForm({ ...form, data_pesagem: e.target.value })}
+            required
+          />
+          <input
+            type="number"
+            step="0.1"
+            placeholder="Peso atual"
+            value={form.peso_atual}
+            onChange={e => setForm({ ...form, peso_atual: e.target.value })}
+            required
+          />
+          <input
+            type="number"
+            step="0.1"
+            placeholder="Peso previsto"
+            value={form.peso_previsto}
+            onChange={e => setForm({ ...form, peso_previsto: e.target.value })}
+            required
+          />
+          <button type="submit">Salvar</button>
+        </form>
+      </div>
+      <div className="card">
+        <h2>Clientes</h2>
+        {clientes.map(c => (
+          <div key={c.id} className="cliente">
+            <strong>{c.nome}</strong>
+            <ul>
+              {c.previsoes.map(p => (
+                <li key={p.id}>
+                  {new Date(p.data_pesagem).toLocaleDateString()} - {p.peso_atual}kg / {p.peso_previsto}kg
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default Home;
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './style.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
+

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -11,6 +11,21 @@ body {
   padding: 1rem;
 }
 
+nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+nav a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
 .card {
   background: white;
   padding: 1rem;
@@ -23,6 +38,12 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+input, select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 button {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,14 @@
+export type Previsao = {
+  id: number;
+  data_pesagem: string;
+  peso_atual: number;
+  peso_previsto: number;
+};
+
+export type Cliente = {
+  id: number;
+  nome: string;
+  previsoes: Previsao[];
+  objetivo?: { descricao: string } | null;
+};
+


### PR DESCRIPTION
## Summary
- add navigation with routes for predictions, client signup and dashboard
- implement client signup form and weight tracking dashboard with charts
- improve styling for inputs and layout

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0815b91c8832caa86bbcc7d2b2310