### PR TITLE
feat: add auth dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-POSTGRES_DB=peso
-DATABASE_URL=postgres://postgres:postgres@db:5432/peso
+POSTGRES_DB=postgres
 DB_PORT=5432
 BACKEND_PORT=3001
 FRONTEND_PORT=3000
+DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+JWT_SECRET=supersecret

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,12 +10,16 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.14.0",
+        "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.3.0",
         "nodemon": "^3.1.10",
         "prisma": "^6.14.0",
@@ -184,6 +188,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -247,10 +258,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -368,6 +397,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -424,6 +462,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -725,6 +769,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1187,6 +1240,91 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1617,7 +1755,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,12 +16,16 @@
   "license": "ISC",
   "dependencies": {
     "@prisma/client": "^6.14.0",
+    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.3.0",
     "nodemon": "^3.1.10",
     "prisma": "^6.14.0",

--- a/backend/prisma/migrations/2_usuario_jwt/migration.sql
+++ b/backend/prisma/migrations/2_usuario_jwt/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('CLIENTE', 'TREINADOR');
+
+-- CreateTable
+CREATE TABLE "Usuario" (
+  "id" SERIAL PRIMARY KEY,
+  "nome" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "senha" TEXT NOT NULL,
+  "role" "Role" NOT NULL,
+  "clienteId" INTEGER UNIQUE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Usuario_email_key" ON "Usuario"("email");
+CREATE UNIQUE INDEX "Usuario_clienteId_key" ON "Usuario"("clienteId");
+
+-- AlterTable
+ALTER TABLE "Cliente" ADD COLUMN "treinadorId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "Usuario" ADD CONSTRAINT "Usuario_clienteId_fkey" FOREIGN KEY ("clienteId") REFERENCES "Cliente"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Cliente" ADD CONSTRAINT "Cliente_treinadorId_fkey" FOREIGN KEY ("treinadorId") REFERENCES "Usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,6 +7,11 @@ generator client {
   provider = "prisma-client-js"
 }
 
+enum Role {
+  CLIENTE
+  TREINADOR
+}
+
 model Cliente {
   id              Int        @id @default(autoincrement())
   nome            String
@@ -20,6 +25,9 @@ model Cliente {
   percent_gordura Float?
   percent_massa   Float?
   previsoes       Previsao[]
+  treinador       Usuario?  @relation("TreinadorClientes", fields: [treinadorId], references: [id])
+  treinadorId     Int?
+  usuario         Usuario?  @relation("UserCliente")
 }
 
 model Objetivo {
@@ -37,4 +45,15 @@ model Previsao {
   id_cliente    Int
   peso_atual    Float?
   peso_previsto Float
+}
+
+model Usuario {
+  id         Int      @id @default(autoincrement())
+  nome       String
+  email      String   @unique
+  senha      String
+  role       Role
+  cliente    Cliente? @relation("UserCliente", fields: [clienteId], references: [id])
+  clienteId  Int?     @unique
+  clientes   Cliente[] @relation("TreinadorClientes")
 }

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+const secret = process.env.JWT_SECRET || 'secret';
+
+export interface AuthPayload {
+  id: number;
+  role: 'CLIENTE' | 'TREINADOR';
+  clienteId?: number | null;
+}
+
+export interface AuthRequest extends Request {
+  user?: AuthPayload;
+}
+
+export const generateToken = (payload: AuthPayload) => {
+  return jwt.sign(payload, secret, { expiresIn: '1d' });
+};
+
+export const authenticate = (req: AuthRequest, res: Response, next: NextFunction) => {
+  const auth = req.headers.authorization;
+  if (!auth) return res.status(401).json({ error: 'Token required' });
+  const [, token] = auth.split(' ');
+  try {
+    const decoded = jwt.verify(token, secret) as AuthPayload;
+    req.user = decoded;
+    next();
+  } catch (e) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import cors from 'cors';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Role } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+import { authenticate, generateToken, AuthRequest } from './auth';
 
 const app = express();
 const prisma = new PrismaClient();
@@ -8,16 +10,62 @@ const prisma = new PrismaClient();
 app.use(cors());
 app.use(express.json());
 
-app.get('/clientes', async (_req, res) => {
-  const clientes = await prisma.cliente.findMany({
-    include: { objetivo: true, previsoes: true }
-  });
-  res.json(clientes);
+// User registration
+app.post('/usuarios', async (req, res) => {
+  try {
+    const { nome, email, senha, role, clienteId } = req.body as {
+      nome: string;
+      email: string;
+      senha: string;
+      role: Role;
+      clienteId?: number;
+    };
+    const hashed = await bcrypt.hash(senha, 10);
+    const usuario = await prisma.usuario.create({
+      data: { nome, email, senha: hashed, role, clienteId },
+    });
+    res.status(201).json(usuario);
+  } catch (e: any) {
+    res.status(400).json({ error: 'Invalid data', details: e.message });
+  }
 });
 
-app.post('/clientes', async (req, res) => {
+// Login endpoint
+app.post('/login', async (req, res) => {
+  const { email, senha } = req.body as { email: string; senha: string };
+  const usuario = await prisma.usuario.findUnique({ where: { email } });
+  if (!usuario || !(await bcrypt.compare(senha, usuario.senha))) {
+    return res.status(401).json({ error: 'Credenciais inválidas' });
+  }
+  const token = generateToken({ id: usuario.id, role: usuario.role, clienteId: usuario.clienteId });
+  res.json({ token, role: usuario.role, clienteId: usuario.clienteId });
+});
+
+app.get('/clientes', authenticate, async (req: AuthRequest, res) => {
+  if (req.user?.role === 'TREINADOR') {
+    const clientes = await prisma.cliente.findMany({
+      where: { treinadorId: req.user.id },
+      include: { objetivo: true, previsoes: true },
+    });
+    return res.json(clientes);
+  }
+  if (req.user?.clienteId) {
+    const cliente = await prisma.cliente.findUnique({
+      where: { id: req.user.clienteId },
+      include: { objetivo: true, previsoes: true },
+    });
+    return res.json(cliente ? [cliente] : []);
+  }
+  res.json([]);
+});
+
+app.post('/clientes', authenticate, async (req: AuthRequest, res) => {
   try {
-    const cliente = await prisma.cliente.create({ data: req.body });
+    const data = req.body;
+    if (req.user?.role === 'TREINADOR') {
+      data.treinadorId = req.user.id;
+    }
+    const cliente = await prisma.cliente.create({ data });
     res.status(201).json(cliente);
   } catch (e: any) {
     res.status(400).json({ error: 'Invalid data', details: e.message });
@@ -38,14 +86,36 @@ app.post('/objetivos', async (req, res) => {
   }
 });
 
-app.get('/previsoes', async (_req, res) => {
-  const previsoes = await prisma.previsao.findMany({ include: { cliente: true } });
-  res.json(previsoes);
+app.get('/previsoes', authenticate, async (req: AuthRequest, res) => {
+  if (req.user?.role === 'TREINADOR') {
+    const previsoes = await prisma.previsao.findMany({
+      where: { cliente: { treinadorId: req.user.id } },
+      include: { cliente: true },
+    });
+    return res.json(previsoes);
+  }
+  if (req.user?.clienteId) {
+    const previsoes = await prisma.previsao.findMany({
+      where: { id_cliente: req.user.clienteId },
+      include: { cliente: true },
+    });
+    return res.json(previsoes);
+  }
+  res.json([]);
 });
 
-app.post('/previsoes', async (req, res) => {
+app.post('/previsoes', authenticate, async (req: AuthRequest, res) => {
   try {
-    const previsao = await prisma.previsao.create({ data: req.body });
+    const data = req.body;
+    if (req.user?.role === 'CLIENTE' && req.user.clienteId) {
+      data.id_cliente = req.user.clienteId;
+    } else if (req.user?.role === 'TREINADOR') {
+      const cliente = await prisma.cliente.findFirst({
+        where: { id: data.id_cliente, treinadorId: req.user.id },
+      });
+      if (!cliente) return res.status(403).json({ error: 'Sem acesso ao cliente' });
+    }
+    const previsao = await prisma.previsao.create({ data });
     res.status(201).json(previsao);
   } catch (e: any) {
     res.status(400).json({ error: 'Invalid data', details: e.message });
@@ -53,16 +123,25 @@ app.post('/previsoes', async (req, res) => {
 });
 
 // Generate weekly predictions based on start weight, goal and number of weeks
-app.post('/previsoes/planejar', async (req, res) => {
+app.post('/previsoes/planejar', authenticate, async (req: AuthRequest, res) => {
   try {
     const { id_cliente, peso_atual, peso_meta, semanas, data_inicio } = req.body as {
-      id_cliente: number;
+      id_cliente?: number;
       peso_atual: number;
       peso_meta: number;
       semanas: number;
       data_inicio?: string;
     };
-
+    const clientId = req.user?.role === 'CLIENTE' ? req.user.clienteId : id_cliente;
+    if (!clientId) {
+      return res.status(400).json({ error: 'id_cliente required' });
+    }
+    if (req.user?.role === 'TREINADOR') {
+      const cliente = await prisma.cliente.findFirst({
+        where: { id: clientId, treinadorId: req.user.id },
+      });
+      if (!cliente) return res.status(403).json({ error: 'Sem acesso ao cliente' });
+    }
     const startDate = data_inicio ? new Date(data_inicio) : new Date();
     const step = (peso_meta - peso_atual) / semanas;
 
@@ -70,7 +149,7 @@ app.post('/previsoes/planejar', async (req, res) => {
       const data_pesagem = new Date(startDate);
       data_pesagem.setDate(startDate.getDate() + (i + 1) * 7);
       return {
-        id_cliente,
+        id_cliente: clientId,
         data_pesagem,
         peso_previsto: Number((peso_atual + step * (i + 1)).toFixed(2)),
         peso_atual: null,
@@ -88,7 +167,7 @@ app.post('/previsoes/planejar', async (req, res) => {
 });
 
 // Update actual weight for a prediction
-app.put('/previsoes/:id', async (req, res) => {
+app.put('/previsoes/:id', authenticate, async (req: AuthRequest, res) => {
   const id = Number(req.params.id);
 
   try {
@@ -104,9 +183,21 @@ app.put('/previsoes/:id', async (req, res) => {
       return res.status(400).json({ error: 'Invalid peso_atual' });
     }
 
+    const existing = await prisma.previsao.findUnique({ include: { cliente: true }, where: { id } });
+    if (!existing) return res.status(404).json({ error: 'Not found' });
+    if (
+      req.user?.role === 'CLIENTE' && existing.id_cliente !== req.user.clienteId
+    ) {
+      return res.status(403).json({ error: 'Sem acesso' });
+    }
+    if (
+      req.user?.role === 'TREINADOR' && existing.cliente.treinadorId !== req.user.id
+    ) {
+      return res.status(403).json({ error: 'Sem acesso' });
+    }
     const previsao = await prisma.previsao.update({
       where: { id },
-      data: { peso_atual: pesoAtual }, // Prisma: campo deve ser Float? (nullable)
+      data: { peso_atual: pesoAtual },
     });
 
     res.json(previsao);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - db
     environment:
       DATABASE_URL: ${DATABASE_URL}
+      JWT_SECRET: ${JWT_SECRET}
     command: sh -c "npm run prisma:migrate && npx prisma generate && node dist/index.js"
     ports:
       - "${BACKEND_PORT}:3001"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,20 +3,25 @@ import { Routes, Route, Link } from 'react-router-dom';
 import Home from './Home';
 import CadastroCliente from './CadastroCliente';
 import Dashboard from './Dashboard';
+import Login from './Login';
 
 const App: React.FC = () => {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    return <Login />;
+  }
   return (
     <div className="container">
       <h1>Gestão de Peso</h1>
       <nav>
-        <Link to="/">Previsões</Link>
+        <Link to="/">Dashboard</Link>
+        <Link to="/previsoes">Previsões</Link>
         <Link to="/cadastro">Cadastrar Cliente</Link>
-        <Link to="/dashboard">Dashboard</Link>
       </nav>
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/previsoes" element={<Home />} />
         <Route path="/cadastro" element={<CadastroCliente />} />
-        <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
     </div>
   );

--- a/frontend/src/CadastroCliente.tsx
+++ b/frontend/src/CadastroCliente.tsx
@@ -10,6 +10,7 @@ const CadastroCliente: React.FC = () => {
   const [percentMassa, setPercentMassa] = React.useState('');
   const [idObjetivo, setIdObjetivo] = React.useState('');
   const [objetivos, setObjetivos] = React.useState<Objetivo[]>([]);
+  const token = localStorage.getItem('token');
 
   React.useEffect(() => {
     fetch('http://localhost:3001/objetivos')
@@ -21,7 +22,7 @@ const CadastroCliente: React.FC = () => {
     e.preventDefault();
     await fetch('http://localhost:3001/clientes', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({
         nome,
         data_nascimento: dataNascimento || null,

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -16,19 +16,57 @@ Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip, L
 const Dashboard: React.FC = () => {
   const [clientes, setClientes] = React.useState<Cliente[]>([]);
   const [idCliente, setIdCliente] = React.useState('');
+  const role = localStorage.getItem('role');
+  const token = localStorage.getItem('token');
 
   React.useEffect(() => {
-    fetch('http://localhost:3001/clientes')
-      .then(r => r.json())
-      .then(setClientes);
-  }, []);
+    fetch('http://localhost:3001/clientes', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        setClientes(data);
+        if (role === 'CLIENTE' && data.length > 0) {
+          setIdCliente(String(data[0].id));
+        }
+      });
+  }, [token, role]);
 
-  const cliente = clientes.find(c => c.id === Number(idCliente));
+  const cliente = clientes.find((c) => c.id === Number(idCliente));
   const previsoes = cliente
     ? [...cliente.previsoes].sort(
         (a, b) => new Date(a.data_pesagem).getTime() - new Date(b.data_pesagem).getTime()
       )
     : [];
+
+  const ultimoPesoEntry = [...previsoes]
+    .filter((p) => p.peso_atual !== null)
+    .slice(-1)[0];
+  const ultimoPeso = ultimoPesoEntry?.peso_atual ?? null;
+  const pesoMeta = previsoes.length
+    ? previsoes[previsoes.length - 1].peso_previsto
+    : null;
+  const diff =
+    ultimoPeso !== null && pesoMeta
+      ? (((ultimoPeso - pesoMeta) / pesoMeta) * 100).toFixed(2)
+      : null;
+
+  const handleAdd = async () => {
+    const peso = prompt('Informe o peso');
+    if (!peso) return;
+    await fetch('http://localhost:3001/previsoes', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ id_cliente: Number(idCliente), data_pesagem: new Date(), peso_atual: Number(peso), peso_previsto: Number(peso) }),
+    });
+    const data = await fetch('http://localhost:3001/clientes', {
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((r) => r.json());
+    setClientes(data);
+  };
 
   const data = {
     labels: previsoes.map(p => new Date(p.data_pesagem).toLocaleDateString('pt-BR')),
@@ -51,15 +89,27 @@ const Dashboard: React.FC = () => {
   return (
     <div className="card">
       <h2>Dashboard</h2>
-      <select value={idCliente} onChange={e => setIdCliente(e.target.value)}>
-        <option value="">Selecione o cliente</option>
-        {clientes.map(c => (
-          <option key={c.id} value={c.id}>
-            {c.nome}
-          </option>
-        ))}
-      </select>
-      {cliente && <Line data={data} />}
+      {role === 'TREINADOR' && (
+        <select value={idCliente} onChange={(e) => setIdCliente(e.target.value)}>
+          <option value="">Selecione o cliente</option>
+          {clientes.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.nome}
+            </option>
+          ))}
+        </select>
+      )}
+      {cliente && (
+        <>
+          <p>Último peso: {ultimoPeso ?? '-'}</p>
+          <p>Peso meta: {pesoMeta ?? '-'}</p>
+          <p>
+            Diferença: {diff !== null ? `${diff}%` : '-'}
+          </p>
+          <button onClick={handleAdd}>+</button>
+          <Line data={data} />
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -21,10 +21,13 @@ const Home: React.FC = () => {
   const [idClienteLista, setIdClienteLista] = React.useState('');
   const [filtro, setFiltro] = React.useState('');
   const [edits, setEdits] = React.useState<Record<number, string | undefined>>({});
+  const token = localStorage.getItem('token');
 
   const loadClientes = async () => {
     try {
-      const res = await fetch('http://localhost:3001/clientes');
+      const res = await fetch('http://localhost:3001/clientes', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       const data = await res.json();
       setClientes(data);
     } catch (err) {
@@ -42,7 +45,7 @@ const Home: React.FC = () => {
     try {
       await fetch('http://localhost:3001/previsoes/planejar', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({
           id_cliente: Number(plan.id_cliente),
           peso_atual: Number(plan.peso_atual),
@@ -73,7 +76,7 @@ const Home: React.FC = () => {
     try {
       await fetch(`http://localhost:3001/previsoes/${id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify(payload),
       });
       setEdits((e) => {

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const Login: React.FC = () => {
+  const [email, setEmail] = React.useState('');
+  const [senha, setSenha] = React.useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:3001/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, senha }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      localStorage.setItem('role', data.role);
+      if (data.clienteId) localStorage.setItem('clienteId', data.clienteId);
+      navigate('/');
+    } else {
+      alert('Login inválido');
+    }
+  };
+
+  return (
+    <form className="card" onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Senha"
+        value={senha}
+        onChange={(e) => setSenha(e.target.value)}
+      />
+      <button type="submit">Entrar</button>
+    </form>
+  );
+};
+
+export default Login;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,4 +20,5 @@ export type Cliente = {
   percent_massa?: number | null;
   previsoes: Previsao[];
   objetivo?: Objetivo | null;
+  treinadorId?: number | null;
 };


### PR DESCRIPTION
## Summary
- implement JWT auth with user roles and restricted routes
- show dashboard with last weight, goal and add measurement
- secure frontend API calls and set dashboard as home

## Testing
- `npm test`
- `npm test`
- `npx prisma migrate dev --name add_usuario_auth` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a3170b6d18832c98d0002a77808d7a