### PR TITLE
feat: add role-based login and seed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ docker-compose up --build
 - `frontend/` Aplicação React com Vite
 - `docker-compose.yml` Orquestração dos serviços
 
+## Usuários de teste
+
+- Treinador: treinador@example.com / senha: treinador123
+- Aluno: aluno@example.com / senha: aluno123 (vinculado ao treinador)
+
+
 ## Próximos passos
 
 - Autenticação de usuários

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,5 +31,8 @@
     "prisma": "^6.14.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   }
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,53 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // trainer account
+  const trainerEmail = 'treinador@example.com';
+  const alunoEmail = 'aluno@example.com';
+
+  const trainerPassword = await bcrypt.hash('treinador123', 10);
+  const alunoPassword = await bcrypt.hash('aluno123', 10);
+
+  const trainer = await prisma.usuario.upsert({
+    where: { email: trainerEmail },
+    update: {},
+    create: {
+      nome: 'Treinador Exemplo',
+      email: trainerEmail,
+      senha: trainerPassword,
+      role: 'TREINADOR',
+    },
+  });
+
+  const existingAluno = await prisma.usuario.findUnique({ where: { email: alunoEmail } });
+  if (!existingAluno) {
+    const cliente = await prisma.cliente.create({
+      data: {
+        nome: 'Aluno Exemplo',
+        treinadorId: trainer.id,
+      },
+    });
+
+    await prisma.usuario.create({
+      data: {
+        nome: 'Aluno Exemplo',
+        email: alunoEmail,
+        senha: alunoPassword,
+        role: 'CLIENTE',
+        clienteId: cliente.id,
+      },
+    });
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -11,5 +11,9 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true
-  }
+  },
+  "exclude": [
+    "prisma",
+    "dist"
+  ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL}
       JWT_SECRET: ${JWT_SECRET}
-    command: sh -c "npm run prisma:migrate && npx prisma generate && node dist/index.js"
+    command: sh -c "npm run prisma:migrate && npx prisma generate && npx prisma db seed && node dist/index.js"
     ports:
       - "${BACKEND_PORT}:3001"
   frontend:

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 const Login: React.FC = () => {
   const [email, setEmail] = React.useState('');
   const [senha, setSenha] = React.useState('');
+  const [tipo, setTipo] = React.useState<'aluno' | 'treinador'>('aluno');
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -25,22 +26,40 @@ const Login: React.FC = () => {
   };
 
   return (
-    <form className="card" onSubmit={handleSubmit}>
-      <h2>Login</h2>
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="Senha"
-        value={senha}
-        onChange={(e) => setSenha(e.target.value)}
-      />
-      <button type="submit">Entrar</button>
-    </form>
+    <div className="card">
+      <div className="login-options">
+        <button
+          type="button"
+          className={tipo === 'aluno' ? 'active' : ''}
+          onClick={() => setTipo('aluno')}
+        >
+          Login aluno
+        </button>
+        <button
+          type="button"
+          className={tipo === 'treinador' ? 'active' : ''}
+          onClick={() => setTipo('treinador')}
+        >
+          Login treinador
+        </button>
+      </div>
+      <form onSubmit={handleSubmit}>
+        <h2>{tipo === 'aluno' ? 'Login Aluno' : 'Login Treinador'}</h2>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={senha}
+          onChange={(e) => setSenha(e.target.value)}
+        />
+        <button type="submit">Entrar</button>
+      </form>
+    </div>
   );
 };
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -88,3 +88,10 @@ td button {
     padding: 0.5rem;
   }
 }
+.login-options {
+  flex-direction: row;
+  margin-bottom: 1rem;
+}
+.login-options button.active {
+  background: #0056b3;
+}


### PR DESCRIPTION
## Summary
- add script to seed default trainer and student users
- show separate "Login aluno" and "Login treinador" options
- run seed on startup via docker-compose

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`
- `cd backend && npm run build`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a31de5e3b4832c8e270911fb943ef4