### PR TITLE
fix: update Prisma enum usage and Docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,5 +3,6 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+RUN npm run prisma:generate
 RUN npm run build
 CMD ["node", "dist/index.js"]

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,11 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { $Enums } from '@prisma/client';
 
 const secret = process.env.JWT_SECRET || 'secret';
 
 export interface AuthPayload {
   id: number;
-  role: 'CLIENTE' | 'TREINADOR';
+  role: $Enums.Role;
   clienteId?: number | null;
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import { PrismaClient, Role } from '@prisma/client';
+import { PrismaClient, $Enums } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 import { authenticate, generateToken, AuthRequest } from './auth';
 
@@ -17,7 +17,7 @@ app.post('/usuarios', async (req, res) => {
       nome: string;
       email: string;
       senha: string;
-      role: Role;
+      role: $Enums.Role;
       clienteId?: number;
     };
     const hashed = await bcrypt.hash(senha, 10);


### PR DESCRIPTION
## Summary
- use Prisma's new $Enums-based Role type
- run Prisma client generation during Docker build

## Testing
- `npm run prisma:generate`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a328386b40832c9c5c2ab9f86917ef