### PR TITLE
fix(frontend): route API requests to backend container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ BACKEND_PORT=3001
 FRONTEND_PORT=3000
 DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
 JWT_SECRET=supersecret
+VITE_API_URL=http://backend:3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,14 @@ services:
     ports:
       - "${BACKEND_PORT}:3001"
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        VITE_API_URL: ${VITE_API_URL}
     depends_on:
       - backend
+    environment:
+      VITE_API_URL: ${VITE_API_URL}
     ports:
       - "${FRONTEND_PORT}:3000"
 volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
 RUN npm run build
 EXPOSE 3000
-CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0"]
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "3000"]

--- a/frontend/src/CadastroCliente.tsx
+++ b/frontend/src/CadastroCliente.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Objetivo } from './types';
+import { API_URL } from './api';
 
 const CadastroCliente: React.FC = () => {
   const [nome, setNome] = React.useState('');
@@ -13,14 +14,14 @@ const CadastroCliente: React.FC = () => {
   const token = localStorage.getItem('token');
 
   React.useEffect(() => {
-    fetch('http://localhost:3001/objetivos')
+    fetch(`${API_URL}/objetivos`)
       .then((r) => r.json())
       .then(setObjetivos);
   }, []);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch('http://localhost:3001/clientes', {
+    await fetch(`${API_URL}/clientes`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import { Cliente } from './types';
+import { API_URL } from './api';
 
 Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Legend);
 
@@ -20,7 +21,7 @@ const Dashboard: React.FC = () => {
   const token = localStorage.getItem('token');
 
   React.useEffect(() => {
-    fetch('http://localhost:3001/clientes', {
+    fetch(`${API_URL}/clientes`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => r.json())
@@ -54,7 +55,7 @@ const Dashboard: React.FC = () => {
   const handleAdd = async () => {
     const peso = prompt('Informe o peso');
     if (!peso) return;
-    await fetch('http://localhost:3001/previsoes', {
+    await fetch(`${API_URL}/previsoes`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -62,7 +63,7 @@ const Dashboard: React.FC = () => {
       },
       body: JSON.stringify({ id_cliente: Number(idCliente), data_pesagem: new Date(), peso_atual: Number(peso), peso_previsto: Number(peso) }),
     });
-    const data = await fetch('http://localhost:3001/clientes', {
+    const data = await fetch(`${API_URL}/clientes`, {
       headers: { Authorization: `Bearer ${token}` },
     }).then((r) => r.json());
     setClientes(data);

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Cliente } from './types';
+import { API_URL } from './api';
 
 type PlanState = {
   id_cliente: string;
@@ -25,7 +26,7 @@ const Home: React.FC = () => {
 
   const loadClientes = async () => {
     try {
-      const res = await fetch('http://localhost:3001/clientes', {
+      const res = await fetch(`${API_URL}/clientes`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -43,7 +44,7 @@ const Home: React.FC = () => {
   const criarPlano = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await fetch('http://localhost:3001/previsoes/planejar', {
+      await fetch(`${API_URL}/previsoes/planejar`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({
@@ -74,7 +75,7 @@ const Home: React.FC = () => {
       valor === '' ? { peso_atual: null } : { peso_atual: Math.round(Number(valor) * 100) / 100 };
 
     try {
-      await fetch(`http://localhost:3001/previsoes/${id}`, {
+      await fetch(`${API_URL}/previsoes/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify(payload),

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { API_URL } from './api';
 
 const Login: React.FC = () => {
   const [email, setEmail] = React.useState('');
@@ -9,7 +10,7 @@ const Login: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('http://localhost:3001/login', {
+    const res = await fetch(`${API_URL}/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, senha }),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';


### PR DESCRIPTION
## Summary
- centralize API URL and use backend container address
- pass VITE_API_URL via Docker and compose for builds

## Testing
- `npm test` (frontend)
- `npm test` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_68a32a84501c832cbd016133e1ee4dbf