### PR TITLE
fix: avoid duplicate index in usuario migration

### DIFF
--- a/backend/prisma/migrations/2_usuario_jwt/migration.sql
+++ b/backend/prisma/migrations/2_usuario_jwt/migration.sql
@@ -8,12 +8,12 @@ CREATE TABLE "Usuario" (
   "email" TEXT NOT NULL,
   "senha" TEXT NOT NULL,
   "role" "Role" NOT NULL,
-  "clienteId" INTEGER UNIQUE
+  "clienteId" INTEGER
 );
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Usuario_email_key" ON "Usuario"("email");
-CREATE UNIQUE INDEX "Usuario_clienteId_key" ON "Usuario"("clienteId");
+CREATE UNIQUE INDEX IF NOT EXISTS "Usuario_clienteId_key" ON "Usuario"("clienteId");
 
 -- AlterTable
 ALTER TABLE "Cliente" ADD COLUMN "treinadorId" INTEGER;


### PR DESCRIPTION
## Summary
- prevent duplicate `Usuario_clienteId_key` index by creating it only if missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3590e3fac832ca364618d476ca35f