### PR TITLE
fix: drop duplicate usuario index before creating unique constraint

### DIFF
--- a/backend/prisma/migrations/2_usuario_jwt/migration.sql
+++ b/backend/prisma/migrations/2_usuario_jwt/migration.sql
@@ -13,7 +13,9 @@ CREATE TABLE "Usuario" (
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Usuario_email_key" ON "Usuario"("email");
-CREATE UNIQUE INDEX IF NOT EXISTS "Usuario_clienteId_key" ON "Usuario"("clienteId");
+-- Ensure stale indexes are removed before creating the unique constraint
+DROP INDEX IF EXISTS "Usuario_clienteId_key";
+CREATE UNIQUE INDEX "Usuario_clienteId_key" ON "Usuario"("clienteId");
 
 -- AlterTable
 ALTER TABLE "Cliente" ADD COLUMN "treinadorId" INTEGER;

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,3 +1,6 @@
+-- Clean up potentially conflicting indexes from previous runs
+DROP INDEX IF EXISTS "Usuario_clienteId_key";
+
 CREATE TABLE "Objetivo" (
   "id" SERIAL PRIMARY KEY,
   "descricao" TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- drop existing Usuario_clienteId_key index before recreation
- clear leftover Usuario_clienteId_key index in init.sql

## Testing
- `npm test`
- `npm run prisma:migrate` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a3608f8174832c88141d47456ca5b0